### PR TITLE
Added missing 'content' field for articles

### DIFF
--- a/newsapilib/src/main/java/com/kwabenaberko/newsapilib/models/Article.java
+++ b/newsapilib/src/main/java/com/kwabenaberko/newsapilib/models/Article.java
@@ -12,6 +12,7 @@ public class Article {
     private String url;
     private String urlToImage;
     private String publishedAt;
+    private String content;
 
     public Source getSource() {
         return source;
@@ -67,5 +68,13 @@ public class Article {
 
     public void setPublishedAt(String publishedAt) {
         this.publishedAt = publishedAt;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
     }
 }


### PR DESCRIPTION
Added a `content` field to the `Article` class in order to have access the value of the `content` field in the response JSON for any article. This field stores the first 200 characters of the actual content of an article.   
As can be seen in the documentation [here](https://newsapi.org/docs/endpoints/everything), too.